### PR TITLE
Add missing `Debug` implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! # The interpreter for the StackAssembly programming language
 
+#![warn(missing_debug_implementations)]
 #![warn(missing_docs)]
 
 use std::collections::VecDeque;


### PR DESCRIPTION
Make sure that in the future, any missing `Debug`s will result in a warning.