### PR TITLE
Limit line length to 80 characters

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80


### PR DESCRIPTION
This is the default for my projects, as I find that it results in lines that are both readable and fit on screen next to other parts of the IDE.