### PR TITLE
Clarify name of CI build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run test suite
         run: cargo test
 
-      - name: Check for warnings in documentation
+      - name: Build documentation
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc


### PR DESCRIPTION
It doesn't check for warnings _in_ the documentation. It builds the documentation, and checks for warnings from that build process.