### PR TITLE
Rename `Effect::OutOfTokens` to `OutOfOperators`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,7 @@ impl Eval {
 
     fn evaluate_next_operator(&mut self) -> Result<(), Effect> {
         let Some(operator) = self.operators.get(self.next_operator) else {
-            return Err(Effect::OutOfTokens);
+            return Err(Effect::OutOfOperators);
         };
 
         match operator {
@@ -653,7 +653,7 @@ pub enum Effect {
     /// Triggers when evaluation reaches the end of the script, where no more
     /// operators are available to evaluate. This signals the regular end of the
     /// evaluation.
-    OutOfTokens,
+    OutOfOperators,
 
     /// # Tried popping a value from an empty stack
     ///

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -7,7 +7,7 @@ fn add() {
     let mut eval = Eval::start("1 2 +");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[3]);
 }
 
@@ -18,7 +18,7 @@ fn add_wraps_on_signed_overflow() {
     let mut eval = Eval::start("2147483647 1 +");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[2147483648]);
 }
 
@@ -33,7 +33,7 @@ fn add_wraps_on_unsigned_overflow() {
     let mut eval = Eval::start("-1 1 +");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0]);
 }
 
@@ -44,7 +44,7 @@ fn subtract() {
     let mut eval = Eval::start("2 1 -");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1]);
 }
 
@@ -55,7 +55,7 @@ fn subtract_wraps_on_signed_overflow() {
     let mut eval = Eval::start("-2147483648 1 -");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[2147483647]);
 }
 
@@ -67,7 +67,7 @@ fn subtract_wraps_on_unsigned_overflow() {
     let mut eval = Eval::start("0 1 -");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[4294967295]);
 }
 
@@ -78,7 +78,7 @@ fn multiply() {
     let mut eval = Eval::start("2 3 *");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[6]);
 }
 
@@ -90,7 +90,7 @@ fn multiply_wraps_on_signed_overflow() {
     let mut eval = Eval::start("2147483647 2 *");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[4294967294]);
 }
 
@@ -106,7 +106,7 @@ fn multiply_wraps_on_unsigned_overflow() {
     let mut eval = Eval::start("-1 2 *");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[4294967294]);
 }
 
@@ -118,7 +118,7 @@ fn divide() {
     let mut eval = Eval::start("5 2 /");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[2, 1]);
 }
 
@@ -136,7 +136,7 @@ fn divide_treats_its_inputs_as_signed() {
     let mut eval = Eval::start("5 -2 /");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[4294967294, 1]);
 }
 

--- a/src/tests/bitwise.rs
+++ b/src/tests/bitwise.rs
@@ -11,7 +11,7 @@ fn and() {
     let mut eval = Eval::start("61680 65280 and");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0xf000]);
 }
 
@@ -23,7 +23,7 @@ fn or() {
     let mut eval = Eval::start("61680 65280 or");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0xfff0]);
 }
 
@@ -35,7 +35,7 @@ fn xor() {
     let mut eval = Eval::start("61680 65280 xor");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0x0ff0]);
 }
 
@@ -47,7 +47,7 @@ fn count_ones() {
     let mut eval = Eval::start("61680 count_ones");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[8]);
 }
 
@@ -60,7 +60,7 @@ fn leading_zeros() {
     let mut eval = Eval::start("252645135 leading_zeros");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[4]);
 }
 
@@ -73,7 +73,7 @@ fn trailing_zeros() {
     let mut eval = Eval::start("-252645136 trailing_zeros");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[4]);
 }
 
@@ -86,7 +86,7 @@ fn rotate_left() {
     let mut eval = Eval::start("-268435456 4 rotate_left");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0x0000000f]);
 }
 
@@ -99,7 +99,7 @@ fn rotate_right() {
     let mut eval = Eval::start("15 4 rotate_right");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0xf0000000]);
 }
 
@@ -114,7 +114,7 @@ fn shift_left() {
     let mut eval = Eval::start("-16777216 4 shift_left");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0xf0000000]);
 }
 
@@ -129,7 +129,7 @@ fn shift_right_unsigned() {
     let mut eval = Eval::start("255 4 shift_right");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0x0000000f]);
 }
 
@@ -143,6 +143,6 @@ fn shift_right_signed() {
     let mut eval = Eval::start("-268435201 4 shift_right");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0xff00000f]);
 }

--- a/src/tests/comparison.rs
+++ b/src/tests/comparison.rs
@@ -8,7 +8,7 @@ fn smaller_outputs_one_if_smaller() {
     let mut eval = Eval::start("-1 0 <");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1]);
 }
 
@@ -19,7 +19,7 @@ fn smaller_outputs_zero_if_equal() {
     let mut eval = Eval::start("0 0 <");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0]);
 }
 
@@ -31,7 +31,7 @@ fn smaller_outputs_zero_if_larger() {
     let mut eval = Eval::start("0 -1 <");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0]);
 }
 
@@ -43,7 +43,7 @@ fn smaller_equals_outputs_one_if_smaller() {
     let mut eval = Eval::start("-1 0 <=");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1]);
 }
 
@@ -54,7 +54,7 @@ fn smaller_equals_outputs_one_if_equal() {
     let mut eval = Eval::start("0 0 <=");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1]);
 }
 
@@ -66,7 +66,7 @@ fn smaller_equals_outputs_zero_if_larger() {
     let mut eval = Eval::start("0 -1 <=");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0]);
 }
 
@@ -77,7 +77,7 @@ fn equals_outputs_one_if_equal() {
     let mut eval = Eval::start("3 3 =");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1]);
 }
 
@@ -88,7 +88,7 @@ fn equals_outputs_zero_if_not_equal() {
     let mut eval = Eval::start("3 5 =");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0]);
 }
 
@@ -100,7 +100,7 @@ fn larger_outputs_zero_if_smaller() {
     let mut eval = Eval::start("-1 0 >");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0]);
 }
 
@@ -111,7 +111,7 @@ fn larger_outputs_zero_if_equal() {
     let mut eval = Eval::start("0 0 >");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0]);
 }
 
@@ -123,7 +123,7 @@ fn larger_outputs_one_if_larger() {
     let mut eval = Eval::start("0 -1 >");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1]);
 }
 
@@ -135,7 +135,7 @@ fn larger_equals_outputs_zero_if_smaller() {
     let mut eval = Eval::start("-1 0 >=");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[0]);
 }
 
@@ -146,7 +146,7 @@ fn larger_equals_outputs_one_if_equal() {
     let mut eval = Eval::start("0 0 >=");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1]);
 }
 
@@ -158,6 +158,6 @@ fn larger_equals_outputs_one_if_larger() {
     let mut eval = Eval::start("0 -1 >=");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1]);
 }

--- a/src/tests/control_flow.rs
+++ b/src/tests/control_flow.rs
@@ -29,7 +29,7 @@ fn jump_if_behaves_like_jump_on_nonzero_condition() {
     let mut eval = Eval::start("1 @target jump_if 1 target: 2");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[2]);
 }
 
@@ -42,7 +42,7 @@ fn jump_if_does_nothing_on_zero_condition() {
     let mut eval = Eval::start("0 @target jump_if 1 target: 2");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[1, 2]);
 }
 

--- a/src/tests/evaluation.rs
+++ b/src/tests/evaluation.rs
@@ -7,7 +7,7 @@ fn empty_script_triggers_out_of_tokens() {
     let mut eval = Eval::start("");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[]);
 }
 

--- a/src/tests/integers.rs
+++ b/src/tests/integers.rs
@@ -8,7 +8,7 @@ fn evaluate_positive_integers() {
     let mut eval = Eval::start("3 5");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[3, 5]);
 }
 
@@ -21,7 +21,7 @@ fn evaluate_negative_integer() {
     let mut eval = Eval::start("-1");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[4294967295]);
 }
 

--- a/src/tests/memory.rs
+++ b/src/tests/memory.rs
@@ -9,7 +9,7 @@ fn read() {
     eval.memory.values[1] = Value::from(3);
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[3, 3]);
 }
 
@@ -36,7 +36,7 @@ fn write() {
     let mut eval = Eval::start("1 3 write");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[]);
     assert_eq!(eval.memory.values[1], Value::from(3));
 }

--- a/src/tests/stack_shuffling.rs
+++ b/src/tests/stack_shuffling.rs
@@ -8,7 +8,7 @@ fn copy() {
     let mut eval = Eval::start("3 5 8 1 copy");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[3, 5, 8, 5]);
 }
 
@@ -31,6 +31,6 @@ fn drop() {
     let mut eval = Eval::start("3 5 8 1 drop");
     eval.run();
 
-    assert_eq!(eval.effect, Some(Effect::OutOfTokens));
+    assert_eq!(eval.effect, Some(Effect::OutOfOperators));
     assert_eq!(eval.stack.to_u32_slice(), &[3, 8]);
 }


### PR DESCRIPTION
The new name is more precise. The evaluation ran out of operators, and any other tokens that might also be in the script have no bearing on that.