### PR TITLE
Enable accessing memory as `i32` or `u32` slices

### DIFF
--- a/crates/stack-assembly/src/memory.rs
+++ b/crates/stack-assembly/src/memory.rs
@@ -19,6 +19,11 @@ pub struct Memory {
 }
 
 impl Memory {
+    /// # Access the memory as a slice of `i32` values
+    pub fn to_i32_slice(&self) -> &[i32] {
+        bytemuck::cast_slice(&self.values)
+    }
+
     /// # Access the memory as a slice of `u32` values
     pub fn to_u32_slice(&self) -> &[u32] {
         bytemuck::cast_slice(&self.values)


### PR DESCRIPTION
`Stack` already has methods like this. Making equivalent methods available on `Memory` is useful and consistent.