### PR TITLE
Avoid possible panic when accessing memory

### DIFF
--- a/crates/stack-assembly/src/eval.rs
+++ b/crates/stack-assembly/src/eval.rs
@@ -393,7 +393,7 @@ impl Eval {
                     self.operand_stack.push(value);
                 } else if identifier == "write" {
                     let value = self.operand_stack.pop()?;
-                    let address = self.operand_stack.pop()?.to_usize();
+                    let address = self.operand_stack.pop()?.to_u32();
 
                     self.memory.write(address, value)?;
                 } else {

--- a/crates/stack-assembly/src/memory.rs
+++ b/crates/stack-assembly/src/memory.rs
@@ -38,9 +38,16 @@ impl Memory {
     /// # Write a value to an address
     pub fn write(
         &mut self,
-        address: usize,
+        address: u32,
         value: Value,
     ) -> Result<(), InvalidAddress> {
+        let Ok(address): Result<usize, _> = address.try_into() else {
+            // It is not possible to have memories larger than what can be
+            // addressed by `usize`. So by definition, any address that's too
+            // large to convert to `usize`, can not be valid.
+            return Err(InvalidAddress);
+        };
+
         if address >= self.values.len() {
             return Err(InvalidAddress);
         }


### PR DESCRIPTION
So far, it was possible for reading from or writing to memory to cause a panic on 8- and 16-bit platforms, if the address involved could not be represented by `usize`. This pull request prevents that, triggering the "invalid address" effect instead.