### PR TITLE
Deprecate `Value::to_usize`

### DIFF
--- a/crates/stack-assembly/src/value.rs
+++ b/crates/stack-assembly/src/value.rs
@@ -49,6 +49,10 @@ impl Value {
     /// ## Panics
     ///
     /// Panics, if `usize` can not represent this value.
+    ///
+    /// ## Compatibility Note
+    ///
+    /// This deprecated method will be removed in a future release.
     #[deprecated(
         since = "0.2.0",
         note = "\


### PR DESCRIPTION
It is no longer used internally (see https://github.com/hannobraun/stack-assembly/pull/97, https://github.com/hannobraun/stack-assembly/pull/99, https://github.com/hannobraun/stack-assembly/pull/100) due to its panicking behavior. Because of that, and because there are multiple ways for the user to convert to `usize` themselves, I no longer want to support it as part of the public API.