### PR TITLE
Link workspace-level `readme` key

### DIFF
--- a/crates/stack-assembly/Cargo.toml
+++ b/crates/stack-assembly/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description.workspace = true
 license.workspace = true
 repository.workspace = true
+repository.readme = true
 
 [dependencies.bytemuck]
 version = "1.25.0"


### PR DESCRIPTION
This is another attempt (following up on [#127]) to fix the README not being picked up on crates.io.

[#127]: https://github.com/hannobraun/stack-assembly/pull/127